### PR TITLE
Add referral-focused footer with Thrive branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     ul { padding-left: 20px; }
     li { margin: 6px 0; }
     .footer { margin-top: 24px; color: #666; font-size: 12px; }
+    .footer img { height: 40px; margin-top: 8px; }
   </style>
 </head>
 <body>
@@ -37,7 +38,12 @@ Jonathan Fairly Marvellous Websites"></textarea>
   <ul id="results" aria-live="polite"></ul>
 
   <div class="footer">
-    Uses LinkedIn’s public search: <code>/search/results/all?keywords=&lt;query&gt;</code>.
+    Uses LinkedIn’s public search: <code>/search/results/all?keywords=&lt;query&gt;</code>.<br />
+    Built with referrals in mind by Chris Gage from <a href="https://thrivehomecare.co.uk" target="_blank" rel="noopener">Thrive Homecare</a>,
+    part of <a href="https://planwithcare.co.uk" target="_blank" rel="noopener">Plan with Care</a>.<br />
+    <a href="https://thrivehomecare.co.uk" target="_blank" rel="noopener">
+      <img src="https://static.wixstatic.com/media/3cbab2_a584714b048842648b34615dd1dc792a~mv2.png/v1/fill/w_478,h_240,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/thrive-logo-CutOut.png" alt="Thrive Homecare logo" />
+    </a>
   </div>
 
 <script>


### PR DESCRIPTION
## Summary
- add footer referencing Thrive Homecare and Plan with Care, including Thrive logo

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bfb45b892c83278dccac8b977c9507