### PR TITLE
Add LinkedIn icons, rename app, and improve sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# LinkedIn Search Link Builder
+# Quick LinkedIn Referral Finder for BNI Chapters
 
 This is a static web app that lets you paste a list of names (optionally with companies) and instantly get LinkedIn search links.
 
 ## How to use
 - Enter one person per line in the textarea.
 - Links are generated automatically as you type.
-- Use **Open all in tabs** to launch every search in a new tab.
-- Use **Copy shareable link** to generate a URL with your list embedded.
+- Use **Open all in LinkedIn** to launch every search in a new tab (appears when there are at least two names).
+- Use **Copy shareable link** to generate a URL with your list embedded. Share it with the rest of the chapter to save time and increase referrals.
 
 ## Deployment on Vercel
 1. Push this repo to GitHub.

--- a/index.html
+++ b/index.html
@@ -3,42 +3,44 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>LinkedIn Search Link Builder</title>
+  <title>Quick LinkedIn Referral Finder for BNI Chapters</title>
   <style>
     :root { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
     body { margin: 0; padding: 24px; }
-    h1 { margin: 0 0 8px }
+  h1 { margin: 0 0 8px }
     p.hint { margin: 0 0 16px; color: #555 }
     textarea { width: 100%; min-height: 160px; padding: 12px; box-sizing: border-box; font: inherit; }
     .row { display: flex; gap: 8px; flex-wrap: wrap; margin: 12px 0 20px; }
     button, input[type="text"] { font: inherit; padding: 10px 12px; }
     button { cursor: pointer; }
     #shareUrl { flex: 1 1 360px; min-width: 240px; }
+    li img.icon { width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; }
+    #openAll { display: none; margin-top: 12px; }
 
       ul { padding-left: 20px; }
       li { margin: 6px 0; }
-      #openAll { margin-top: 12px; }
       .footer { margin-top: 24px; color: #666; font-size: 12px; }
     .footer img { height: 40px; margin-top: 8px; }
   </style>
 
 </head>
 <body>
-  <h1>LinkedIn Search Link Builder</h1>
+  <h1>Quick LinkedIn Referral Finder for BNI Chapters</h1>
   <p class="hint">Enter one person per line (e.g. <em>Chris Gage, Thrive Homecare</em> or <em>John Smith, Acme Ltd</em>).</p>
 
   <textarea id="people" placeholder="Chris Gage, Thrive Homecare
 Jane Doe, Example Ltd
 John Smith Marketing"></textarea>
 
+    <ul id="results" aria-live="polite"></ul>
+
+      <button id="openAll">Open all in LinkedIn</button>
+
     <div class="row">
       <button id="copyShare">Copy shareable link</button>
       <input id="shareUrl" type="text" readonly placeholder="Shareable URL will appear here" />
     </div>
-
-    <ul id="results" aria-live="polite"></ul>
-
-      <button id="openAll">Open all in tabs</button>
+    <p class="hint">Copy the link and share with the rest of the chapter to save you all time and increase referrals.</p>
 
   <div class="footer">
     Built with referrals in mind by <a href="https://bnikent.co.uk/en-GB/memberdetails?encryptedMemberId=Q88w1PE3FMylGImDTiEfrQ%3D%3D&cmsv3=true&name=Chris+Gage" target="_blank" rel="noopener">Chris Gage</a> from <a href="https://thrivehomecare.co.uk" target="_blank" rel="noopener">Thrive Homecare</a>,
@@ -54,6 +56,7 @@ John Smith Marketing"></textarea>
   const peopleEl = $('#people');
   const resultsEl = $('#results');
   const shareEl = $('#shareUrl');
+  const openAllEl = $('#openAll');
 
   function liUrl(q) {
     const url = 'https://www.linkedin.com/search/results/all?keywords=' + encodeURIComponent(q.trim().replace(/\s+/g, ' ').replace(/\s*,\s*/g, ' '));
@@ -62,17 +65,24 @@ John Smith Marketing"></textarea>
 
   function render(list) {
     resultsEl.innerHTML = '';
-    list.filter(Boolean).forEach(q => {
+    const filtered = list.filter(Boolean);
+    filtered.forEach(q => {
       const { label, url } = liUrl(q);
       const li = document.createElement('li');
+      const icon = document.createElement('img');
+      icon.src = 'https://cdn-icons-png.flaticon.com/512/174/174857.png';
+      icon.alt = 'LinkedIn';
+      icon.className = 'icon';
       const a = document.createElement('a');
       a.href = url;
       a.target = '_blank';
       a.rel = 'noopener';
       a.textContent = label;
+      li.appendChild(icon);
       li.appendChild(a);
       resultsEl.appendChild(li);
     });
+    openAllEl.style.display = filtered.length >= 2 ? 'block' : 'none';
   }
 
   function getLines() {
@@ -101,11 +111,11 @@ John Smith Marketing"></textarea>
     }
   }
 
-    $('#openAll').addEventListener('click', () => {
-      const list = getLines();
-      list.forEach(q => {
-        if (q.trim()) {
-          const { url } = liUrl(q);
+  openAllEl.addEventListener('click', () => {
+    const list = getLines();
+    list.forEach(q => {
+      if (q.trim()) {
+        const { url } = liUrl(q);
         window.open(url, '_blank');
       }
     });


### PR DESCRIPTION
## Summary
- rename project to Quick LinkedIn Referral Finder for BNI Chapters
- show LinkedIn icons beside search results and hide bulk open until 2 entries
- move and clarify shareable link instructions for easier chapter referrals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bfc133f854832785ffd31e3fc4cca1