### PR TITLE
Render search results in LinkedIn/Facebook table

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,11 +17,10 @@
     button:hover { background: #f2f2f2; }
     #shareUrl { flex: 1 1 360px; min-width: 240px; border: 1px solid #ddd; border-radius: 8px; }
     img.icon { width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; }
-    li a + a { margin-left: 8px; }
-    #openAllRow { display: none; margin: 12px 0; }
-
-    ul { padding-left: 20px; }
-    li { margin: 6px 0; }
+    #openAllRow { display: none; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 6px 8px; text-align: left; border-bottom: 1px solid #ddd; }
+    tfoot td { border-bottom: none; padding-top: 12px; }
 
     .marketing { margin: 32px 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 24px; }
 
@@ -114,12 +113,18 @@
 Jane Doe, Example Ltd
 John Smith Marketing"></textarea>
 
-  <ul id="results" aria-live="polite"></ul>
-
-  <div id="openAllRow" class="row">
-    <button id="openAllLinkedIn"><img class="icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="LinkedIn" />Open all in LinkedIn</button>
-    <button id="openAllFacebook"><img class="icon" src="https://cdn-icons-png.flaticon.com/512/733/733547.png" alt="Facebook" />Open all in Facebook</button>
-  </div>
+  <table id="results" aria-live="polite">
+    <thead>
+      <tr><th>LinkedIn</th><th>Facebook</th></tr>
+    </thead>
+    <tbody id="resultsBody"></tbody>
+    <tfoot id="openAllRow">
+      <tr>
+        <td><button id="openAllLinkedIn"><img class="icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="LinkedIn" />Open all in LinkedIn</button></td>
+        <td><button id="openAllFacebook"><img class="icon" src="https://cdn-icons-png.flaticon.com/512/733/733547.png" alt="Facebook" />Open all in Facebook</button></td>
+      </tr>
+    </tfoot>
+  </table>
 
   <div class="row">
     <button id="copyShare">Copy shareable link</button>
@@ -166,7 +171,7 @@ John Smith Marketing"></textarea>
     (function () {
       const $ = (sel) => document.querySelector(sel);
       const peopleEl = $('#people');
-      const resultsEl = $('#results');
+      const resultsBodyEl = $('#resultsBody');
       const shareEl = $('#shareUrl');
       const openAllRowEl = $('#openAllRow');
       const openAllLinkedInEl = $('#openAllLinkedIn');
@@ -181,12 +186,13 @@ John Smith Marketing"></textarea>
       }
 
       function render(list) {
-        resultsEl.innerHTML = '';
+        resultsBodyEl.innerHTML = '';
         const filtered = list.filter(Boolean);
         filtered.forEach(q => {
           const { label, liUrl, fbUrl } = searchUrls(q);
-          const li = document.createElement('li');
+          const row = document.createElement('tr');
 
+          const liTd = document.createElement('td');
           const liAnchor = document.createElement('a');
           liAnchor.href = liUrl;
           liAnchor.target = '_blank';
@@ -197,7 +203,10 @@ John Smith Marketing"></textarea>
           liIcon.className = 'icon';
           liAnchor.appendChild(liIcon);
           liAnchor.appendChild(document.createTextNode(label));
+          liTd.appendChild(liAnchor);
+          row.appendChild(liTd);
 
+          const fbTd = document.createElement('td');
           const fbAnchor = document.createElement('a');
           fbAnchor.href = fbUrl;
           fbAnchor.target = '_blank';
@@ -207,12 +216,13 @@ John Smith Marketing"></textarea>
           fbIcon.alt = 'Facebook';
           fbIcon.className = 'icon';
           fbAnchor.appendChild(fbIcon);
+          fbAnchor.appendChild(document.createTextNode(label));
+          fbTd.appendChild(fbAnchor);
+          row.appendChild(fbTd);
 
-          li.appendChild(liAnchor);
-          li.appendChild(fbAnchor);
-          resultsEl.appendChild(li);
+          resultsBodyEl.appendChild(row);
         });
-        openAllRowEl.style.display = filtered.length >= 2 ? 'flex' : 'none';
+        openAllRowEl.style.display = filtered.length >= 2 ? '' : 'none';
       }
 
       function getLines() {


### PR DESCRIPTION
## Summary
- Display results in a table with dedicated LinkedIn and Facebook columns
- Move "open all" actions to table footer and update rendering logic

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c44e2da6bc8327b3b196d9166ef2d3