### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,13 @@
     #shareUrl { flex: 1 1 360px; min-width: 240px; border: 1px solid #ddd; border-radius: 8px; }
     img.icon { width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; }
     #openAllRow { display: none; }
+    .table-wrapper { width: 100%; overflow-x: auto; }
     table { width: 100%; border-collapse: collapse; }
     th, td { padding: 6px 8px; text-align: left; border-bottom: 1px solid #ddd; }
     tfoot td { border-bottom: none; padding-top: 12px; }
+    td .actions { margin-top: 4px; display: flex; gap: 8px; }
+    td .actions img.icon { margin-right: 0; }
+    .mobile-row { display: none; }
 
     .marketing { margin: 32px 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 24px; }
 
@@ -91,12 +95,52 @@
 
     .footer { margin-top: 24px; color: #666; font-size: 12px; }
 
+    @media (max-width: 480px) {
+      body { padding: 16px; }
+      .row { flex-direction: column; align-items: stretch; }
+      .row > * { width: 100%; }
+      #shareUrl { flex: 1 1 auto; min-width: 0; }
+      #results thead { display: none; }
+      #results .desktop-row { display: none; }
+      #results .mobile-row { display: table-row; }
+      #openAllRow { display: none !important; }
+      td .actions { margin-top: 8px; gap: 16px; }
+      td .actions img.icon { width: 24px; height: 24px; }
+    }
+
     @media (max-width: 540px) {
-      .marketing-item { grid-template-columns: 96px 1fr; }
-      .marketing-item img.main { width: 96px; height: 96px; }
-      .marketing-item .content { padding-right: 112px; min-height: 96px; }
-      .marketing-item .company-logo { width: 100px; height: 44px; }
-      .marketing-item .company-logo img { max-height: 36px; max-width: 92px; }
+      .marketing-item {
+        grid-template-columns: 96px 1fr;
+        grid-template-rows: auto auto;
+        padding-bottom: 16px;
+      }
+      .marketing-item a.card-cover {
+        grid-row: 1 / span 2;
+        grid-column: 1;
+      }
+      .marketing-item img.main {
+        width: 96px;
+        height: 96px;
+      }
+      .marketing-item .content {
+        grid-column: 2;
+        grid-row: 1;
+        padding-right: 0;
+        min-height: 0;
+      }
+      .marketing-item .company-logo {
+        position: static;
+        grid-column: 2;
+        grid-row: 2;
+        margin-top: 8px;
+        width: 100px;
+        height: 44px;
+        justify-self: end;
+      }
+      .marketing-item .company-logo img {
+        max-height: 36px;
+        max-width: 92px;
+      }
       .lead-link { font-size: 18px; }
     }
 
@@ -113,17 +157,19 @@
 Bob: Jane Doe, Example Ltd
 John Smith Marketing"></textarea>
 
-  <table id="results" aria-live="polite">
-    <thead>
-      <tr>
-        <th>Requester</th>
-        <th>LinkedIn</th>
-        <th>Facebook</th>
-        <th>Google</th>
-      </tr>
-    </thead>
-    <tbody id="resultsBody"></tbody>
-  </table>
+  <div class="table-wrapper">
+    <table id="results" aria-live="polite">
+      <thead>
+        <tr>
+          <th>Requester</th>
+          <th>LinkedIn</th>
+          <th>Facebook</th>
+          <th>Google</th>
+        </tr>
+      </thead>
+      <tbody id="resultsBody"></tbody>
+    </table>
+  </div>
 
   <div id="openAllRow" class="row">
     <button id="openAllLinkedIn"><img class="icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="LinkedIn" />Open all in LinkedIn</button>
@@ -198,55 +244,72 @@ John Smith Marketing"></textarea>
         filtered.forEach(({ requestor, query }) => {
           const { label, liUrl, fbUrl, gUrl } = searchUrls(query);
 
-          const row = document.createElement('tr');
+          // desktop row
+          const dRow = document.createElement('tr');
+          dRow.className = 'desktop-row';
 
-          const reqTd = document.createElement('td');
-          reqTd.textContent = requestor;
-          row.appendChild(reqTd);
+          const dReqTd = document.createElement('td');
+          dReqTd.textContent = requestor;
+          dRow.appendChild(dReqTd);
 
-          const liTd = document.createElement('td');
-          const liAnchor = document.createElement('a');
-          liAnchor.href = liUrl;
-          liAnchor.target = '_blank';
-          liAnchor.rel = 'noopener';
-          const liIcon = document.createElement('img');
-          liIcon.src = 'https://cdn-icons-png.flaticon.com/512/174/174857.png';
-          liIcon.alt = 'LinkedIn';
-          liIcon.className = 'icon';
-          liAnchor.appendChild(liIcon);
-          liAnchor.appendChild(document.createTextNode(label));
-          liTd.appendChild(liAnchor);
-          row.appendChild(liTd);
+          function createCell(url, src, alt) {
+            const td = document.createElement('td');
+            const a = document.createElement('a');
+            a.href = url;
+            a.target = '_blank';
+            a.rel = 'noopener';
+            const img = document.createElement('img');
+            img.src = src;
+            img.alt = alt;
+            img.className = 'icon';
+            a.appendChild(img);
+            a.appendChild(document.createTextNode(label));
+            td.appendChild(a);
+            return td;
+          }
 
-          const fbTd = document.createElement('td');
-          const fbAnchor = document.createElement('a');
-          fbAnchor.href = fbUrl;
-          fbAnchor.target = '_blank';
-          fbAnchor.rel = 'noopener';
-          const fbIcon = document.createElement('img');
-          fbIcon.src = 'https://cdn-icons-png.flaticon.com/512/733/733547.png';
-          fbIcon.alt = 'Facebook';
-          fbIcon.className = 'icon';
-          fbAnchor.appendChild(fbIcon);
-          fbAnchor.appendChild(document.createTextNode(label));
-          fbTd.appendChild(fbAnchor);
-          row.appendChild(fbTd);
+          dRow.appendChild(createCell(liUrl, 'https://cdn-icons-png.flaticon.com/512/174/174857.png', 'LinkedIn'));
+          dRow.appendChild(createCell(fbUrl, 'https://cdn-icons-png.flaticon.com/512/733/733547.png', 'Facebook'));
+          dRow.appendChild(createCell(gUrl, 'https://www.google.com/favicon.ico', 'Google'));
+          resultsBodyEl.appendChild(dRow);
 
-          const gTd = document.createElement('td');
-          const gAnchor = document.createElement('a');
-          gAnchor.href = gUrl;
-          gAnchor.target = '_blank';
-          gAnchor.rel = 'noopener';
-          const gIcon = document.createElement('img');
-          gIcon.src = 'https://www.google.com/favicon.ico';
-          gIcon.alt = 'Google';
-          gIcon.className = 'icon';
-          gAnchor.appendChild(gIcon);
-          gAnchor.appendChild(document.createTextNode(label));
-          gTd.appendChild(gAnchor);
-          row.appendChild(gTd);
+          // mobile row
+          const mRow = document.createElement('tr');
+          mRow.className = 'mobile-row';
 
-          resultsBodyEl.appendChild(row);
+          const mReqTd = document.createElement('td');
+          mReqTd.textContent = requestor;
+          mRow.appendChild(mReqTd);
+
+          const mSearchTd = document.createElement('td');
+          const nameDiv = document.createElement('div');
+          nameDiv.textContent = label;
+          mSearchTd.appendChild(nameDiv);
+
+          const actionsDiv = document.createElement('div');
+          actionsDiv.className = 'actions';
+
+          function addAction(url, src, alt) {
+            const a = document.createElement('a');
+            a.href = url;
+            a.target = '_blank';
+            a.rel = 'noopener';
+            const img = document.createElement('img');
+            img.src = src;
+            img.alt = alt;
+            img.className = 'icon';
+            a.appendChild(img);
+            actionsDiv.appendChild(a);
+          }
+
+          addAction(liUrl, 'https://cdn-icons-png.flaticon.com/512/174/174857.png', 'LinkedIn');
+          addAction(fbUrl, 'https://cdn-icons-png.flaticon.com/512/733/733547.png', 'Facebook');
+          addAction(gUrl, 'https://www.google.com/favicon.ico', 'Google');
+
+          mSearchTd.appendChild(actionsDiv);
+          mRow.appendChild(mSearchTd);
+
+          resultsBodyEl.appendChild(mRow);
         });
         openAllRowEl.style.display = filtered.length >= 2 ? 'flex' : 'none';
       }


### PR DESCRIPTION
## Summary
- Hide batch "Open all" controls on small screens
- Enlarge and space out action icons for mobile users
- Refine marketing tiles on mobile with square images beside stacked text and logos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c460c8740c83278ccda339c4114740