### PR TITLE
Add meeting details fields to shareable links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a static web app for BNI members to paste a list of names (optionally wi
 - Links are generated automatically as you type.
 - Use **Open all in LinkedIn**, **Open all in Facebook** or **Open all in Google** to launch every search in a new tab (appears when there are at least two names).
 - Use **Copy shareable link** to generate a URL with your list embedded. Share it with the rest of the chapter to save time and increase referrals.
+- Optionally add the meeting name and date; they will be included in the shareable URL.
 
 ## Deployment on Vercel
 1. Push this repo to GitHub.

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     p.hint { margin: 0 0 16px; color: #555 }
     textarea { width: 100%; min-height: 160px; padding: 12px; font: inherit; border: 1px solid #ddd; border-radius: 8px; }
     .row { display: flex; gap: 8px; flex-wrap: wrap; margin: 12px 0 20px; }
-    button, input[type="text"] { font: inherit; padding: 10px 12px; }
+    button, input[type="text"], input[type="date"] { font: inherit; padding: 10px 12px; }
     button { cursor: pointer; border-radius: 8px; border: 1px solid #ddd; background: #fafafa; }
     button:hover { background: #f2f2f2; }
     #shareUrl { flex: 1 1 360px; min-width: 240px; border: 1px solid #ddd; border-radius: 8px; }
@@ -155,6 +155,11 @@
   <h2>How to use</h2>
   <p class="hint">Enter one person per line, optionally starting with the requester's name and a colon (e.g. <em>Alice: Chris Gage, Thrive Homecare</em> or <em>Bob: John Smith, Acme Ltd</em>).</p>
 
+  <div class="row">
+    <input id="meetingName" type="text" placeholder="Meeting name" />
+    <input id="meetingDate" type="date" />
+  </div>
+
   <textarea id="people" placeholder="Alice: Chris Gage, Thrive Homecare
 Bob: Jane Doe, Example Ltd
 John Smith Marketing"></textarea>
@@ -224,6 +229,8 @@ John Smith Marketing"></textarea>
     (function () {
       const $ = (sel) => document.querySelector(sel);
       const peopleEl = $('#people');
+      const meetingNameEl = $('#meetingName');
+      const meetingDateEl = $('#meetingDate');
       const resultsBodyEl = $('#resultsBody');
       const shareEl = $('#shareUrl');
       const openAllRowEl = $('#openAllRow');
@@ -328,11 +335,23 @@ John Smith Marketing"></textarea>
 
       function setShareUrl() {
         const raw = peopleEl.value.trim();
+        const meetingName = meetingNameEl.value.trim();
+        const meetingDate = meetingDateEl.value;
         const url = new URL(window.location.href);
         if (raw) {
           url.searchParams.set('list', raw.replace(/\r?\n/g, '\n'));
         } else {
           url.searchParams.delete('list');
+        }
+        if (meetingName) {
+          url.searchParams.set('meeting', meetingName);
+        } else {
+          url.searchParams.delete('meeting');
+        }
+        if (meetingDate) {
+          url.searchParams.set('date', meetingDate);
+        } else {
+          url.searchParams.delete('date');
         }
         shareEl.value = url.toString();
         window.history.replaceState(null, '', url);
@@ -344,8 +363,16 @@ John Smith Marketing"></textarea>
         if (listParam) {
           peopleEl.value = listParam;
           render(getLines());
-          setShareUrl();
         }
+        const meetingParam = url.searchParams.get('meeting');
+        if (meetingParam) {
+          meetingNameEl.value = meetingParam;
+        }
+        const dateParam = url.searchParams.get('date');
+        if (dateParam) {
+          meetingDateEl.value = dateParam;
+        }
+        setShareUrl();
       }
 
       openAllLinkedInEl.addEventListener('click', () => {
@@ -396,6 +423,9 @@ John Smith Marketing"></textarea>
           setShareUrl();
         }, 250);
       });
+
+      meetingNameEl.addEventListener('input', setShareUrl);
+      meetingDateEl.addEventListener('input', setShareUrl);
 
       loadFromUrl();
     })();


### PR DESCRIPTION
## Summary
- add meeting name and date inputs
- include meeting details in shareable URL parameters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c574498cdc8327add5d603556a1341