### PR TITLE
Ensure pre-filled entries render referral table on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -462,6 +462,7 @@ John Smith Marketing"></textarea>
       meetingDateEl.addEventListener('input', setShareUrl);
 
       loadFromUrl();
+      render(getLines());
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- render the referral results immediately after loading URL-sourced content so pre-filled textarea content displays the table

## Testing
- Playwright script to load the page with pre-filled entries and confirm the referral section is visible

------
https://chatgpt.com/codex/tasks/task_b_68c91808ae00832786e16139831f0ff3