### PR TITLE
Add tool action buttons for blank view and sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,11 @@
 Bob: Jane Doe, Example Ltd
 John Smith Marketing"></textarea>
 
+  <div class="row">
+    <button id="openBlank" type="button">Open blank tool</button>
+    <button id="copyBlank" type="button">Share this tool</button>
+  </div>
+
   <h3>This tool was developed by Thrive to make fellow BNI members' lives that bit better</h3>
   <section class="marketing">
     <div class="marketing-item" tabindex="0">
@@ -435,6 +440,19 @@ John Smith Marketing"></textarea>
       if (copyBlankEl) {
         copyBlankEl.addEventListener('click', async () => {
           const baseUrl = window.location.origin + window.location.pathname;
+          if (navigator.share) {
+            try {
+              await navigator.share({
+                title: 'BNI Referral Contact Generator',
+                url: baseUrl,
+              });
+              return;
+            } catch (err) {
+              if (err && err.name === 'AbortError') {
+                return;
+              }
+            }
+          }
           try {
             await navigator.clipboard.writeText(baseUrl);
           } catch (_) {


### PR DESCRIPTION
## Summary
- add a control row above the marketing section with buttons to open the generator blank in a new tab and to share the tool
- enhance the share action to use the Web Share API when available with a clipboard fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c94b7083288327aa923611cdbcd17f