### PR TITLE
Add support for plain text notes in referral table

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
   <section class="editor-controls">
     <div class="editor-panel">
       <h2>How to use</h2>
-      <p class="hint">Enter one person per line, optionally starting with the requester's name and a colon (e.g. <em>Alice: Chris Gage, Thrive Homecare</em> or <em>Bob: John Smith, Acme Ltd</em>).</p>
+      <p class="hint">Enter one person per line, optionally starting with the requester's name and a colon (e.g. <em>Alice: Chris Gage, Thrive Homecare</em> or <em>Bob: John Smith, Acme Ltd</em>). Start a line with an asterisk (e.g. <em>*Reminder: Bring business cards</em>) to add plain text notes without links.</p>
 
       <div class="row">
         <input id="meetingName" type="text" placeholder="Meeting name" />
@@ -222,6 +222,7 @@
 
       <textarea id="people" placeholder="Alice: Chris Gage, Thrive Homecare
 Bob: Jane Doe, Example Ltd
+*Reminder: Bring business cards
 John Smith Marketing"></textarea>
     </div>
     <div class="row share-tools">
@@ -299,8 +300,46 @@ John Smith Marketing"></textarea>
 
       function render(list) {
         resultsBodyEl.innerHTML = '';
-        const filtered = list.filter(item => item.query.trim());
-        filtered.forEach(({ requestor, query }) => {
+        const filtered = list.filter((item) => {
+          if (item.type === 'note') {
+            return item.text.trim();
+          }
+          if (item.type === 'contact') {
+            return item.query.trim();
+          }
+          return false;
+        });
+        filtered.forEach((item) => {
+          if (item.type === 'note') {
+            const dRow = document.createElement('tr');
+            dRow.className = 'desktop-row note-row';
+
+            const blankTd = document.createElement('td');
+            dRow.appendChild(blankTd);
+
+            const noteTd = document.createElement('td');
+            noteTd.textContent = item.text;
+            dRow.appendChild(noteTd);
+
+            for (let i = 0; i < 2; i += 1) {
+              dRow.appendChild(document.createElement('td'));
+            }
+
+            resultsBodyEl.appendChild(dRow);
+
+            const mRow = document.createElement('tr');
+            mRow.className = 'mobile-row note-row';
+
+            const mTd = document.createElement('td');
+            mTd.colSpan = 2;
+            mTd.textContent = item.text;
+            mRow.appendChild(mTd);
+
+            resultsBodyEl.appendChild(mRow);
+            return;
+          }
+
+          const { requestor, query } = item;
           const { label, liUrl, fbUrl, gUrl } = searchUrls(query);
 
           // desktop row
@@ -368,19 +407,30 @@ John Smith Marketing"></textarea>
           mSearchTd.appendChild(actionsDiv);
           mRow.appendChild(mSearchTd);
 
-        resultsBodyEl.appendChild(mRow);
+          resultsBodyEl.appendChild(mRow);
         });
+        const contactCount = filtered.filter((item) => item.type === 'contact').length;
         referralSectionEl.style.display = filtered.length ? 'block' : 'none';
-        openAllRowEl.style.display = filtered.length >= 2 ? 'table-row' : 'none';
+        openAllRowEl.style.display = contactCount >= 2 ? 'table-row' : 'none';
       }
 
       function getLines() {
-        return peopleEl.value.split(/\r?\n/).map(line => {
+        return peopleEl.value.split(/\r?\n/).map((line) => {
+          const trimmedStart = line.trimStart();
+          if (trimmedStart.startsWith('*')) {
+            const noteBody = trimmedStart.slice(1).trim();
+            if (!noteBody) {
+              return { type: 'note', text: '' };
+            }
+            const [beforeColon, afterColon] = noteBody.split(':', 2);
+            const text = afterColon !== undefined ? afterColon.trim() : beforeColon.trim();
+            return { type: 'note', text };
+          }
           const [requestorPart, queryPart] = line.split(':', 2);
           if (queryPart === undefined) {
-            return { requestor: '', query: requestorPart.trim() };
+            return { type: 'contact', requestor: '', query: requestorPart.trim() };
           }
-          return { requestor: requestorPart.trim(), query: queryPart.trim() };
+          return { type: 'contact', requestor: requestorPart.trim(), query: queryPart.trim() };
         });
       }
 
@@ -479,9 +529,9 @@ John Smith Marketing"></textarea>
 
       openAllLinkedInEl.addEventListener('click', () => {
         const list = getLines();
-        list.forEach(({ query }) => {
-          if (query.trim()) {
-            const { liUrl } = searchUrls(query);
+        list.forEach((item) => {
+          if (item.type === 'contact' && item.query.trim()) {
+            const { liUrl } = searchUrls(item.query);
             window.open(liUrl, '_blank');
           }
         });
@@ -489,9 +539,9 @@ John Smith Marketing"></textarea>
 
       openAllFacebookEl.addEventListener('click', () => {
         const list = getLines();
-        list.forEach(({ query }) => {
-          if (query.trim()) {
-            const { fbUrl } = searchUrls(query);
+        list.forEach((item) => {
+          if (item.type === 'contact' && item.query.trim()) {
+            const { fbUrl } = searchUrls(item.query);
             window.open(fbUrl, '_blank');
           }
         });
@@ -499,9 +549,9 @@ John Smith Marketing"></textarea>
 
       openAllGoogleEl.addEventListener('click', () => {
         const list = getLines();
-        list.forEach(({ query }) => {
-          if (query.trim()) {
-            const { gUrl } = searchUrls(query);
+        list.forEach((item) => {
+          if (item.type === 'contact' && item.query.trim()) {
+            const { gUrl } = searchUrls(item.query);
             window.open(gUrl, '_blank');
           }
         });


### PR DESCRIPTION
## Summary
- allow lines that start with an asterisk to render as plain text notes without generating search links
- show note text in the LinkedIn column on desktop while spanning the mobile layout for readability
- update the editor instructions and placeholder to explain the new note syntax

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68cd11f1cd108327acbf044a8cfb24ed