### PR TITLE
Move share buttons above attribution and rename "General notes" to "General Referals"

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
         </table>
       </div>
 
-      <h3 class="editor-subheading">General notes (not specific)</h3>
+      <h3 class="editor-subheading">General Referals</h3>
       <div class="table-wrapper">
         <table class="entry-table" aria-label="General notes table">
           <thead>
@@ -350,10 +350,6 @@ Family solicitor
 Mortgage broker"></textarea>
         <ul class="join-prospects-list" id="joinProspectsListEditor"></ul>
       </section>
-    </div>
-    <div class="row share-tools">
-      <button id="openBlank" type="button">Open New</button>
-      <button id="copyBlank" type="button">Share the tool</button>
     </div>
   </section>
 
@@ -392,7 +388,7 @@ Mortgage broker"></textarea>
         </tfoot>
       </table>
     </div>
-    <h3 id="noteResultsHeading" class="editor-subheading">General notes (not specific)</h3>
+    <h3 id="noteResultsHeading" class="editor-subheading">General Referals</h3>
     <div id="noteResultsWrapper" class="table-wrapper">
       <table id="noteResults" aria-live="polite">
         <thead>
@@ -422,6 +418,10 @@ Mortgage broker"></textarea>
     <p class="hint">Copy the link and share with the rest of the chapter to save you all time and increase referrals.</p>
   </section>
 
+  <div class="row share-tools">
+    <button id="openBlank" type="button">Open New</button>
+    <button id="copyBlank" type="button">Share the tool</button>
+  </div>
   <h3>This tool was developed by Thrive Homecare to make fellow BNI members' lives that bit better</h3>
   <section class="marketing">
     <div class="marketing-item" tabindex="0">


### PR DESCRIPTION
### Motivation
- Improve page layout by surfacing the share controls outside the editor panel so they are always visible near the attribution. 
- Make the non-specific notes section label clearer for users by renaming the heading displayed in both editor and viewer areas.

### Description
- Moved the `<div class="row share-tools">` block containing the `Open New` and `Share the tool` buttons out of the editor controls and placed it directly above the Thrive Homecare attribution heading. 
- Updated both occurrences of the heading text `General notes (not specific)` to `General Referals` in the editor and results viewer sections of `index.html`.
- No other structural or behavioural changes were made to the markup or existing table/ARIA structure.

### Testing
- Ran `git diff -- index.html` to confirm the expected changes to `index.html` and inspected the produced diff, which matched the intended edits. 
- Ran `git status --short` and `git log -1 --oneline` to verify the working tree and latest change were recorded successfully. 
- No automated unit or integration tests exist for this static HTML change, so no additional test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c6355c9d6883279ca3e911d4c11014)