### PR TITLE
Fix row input focus loss while typing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1209,7 +1209,6 @@ Mortgage broker"></textarea>
         } else {
           entry.note = (row.querySelector('.note')?.value || '').trim();
         }
-        renderEditorTables();
         scheduleUpdates();
       }
 


### PR DESCRIPTION
### Motivation
- While editing an already-added row, the active input lost focus on every keystroke because the editor table was being re-rendered eagerly from the `input` handler.
- The change prevents DOM replacement during typing so the field retains focus while the in-memory model still updates and downstream UI updates remain scheduled.

### Description
- Removed the immediate `renderEditorTables()` call from `handleEditorInput` so typing updates the `entries` model without forcing a synchronous table re-render in `index.html`.
- Continued to call `scheduleUpdates()` from the input handler so `render()` and URL/share updates still occur on a short debounce (250ms).
- The fix is localized to `handleEditorInput` and preserves the existing `is-specific` handling and change/remove handlers.

### Testing
- Ran `git diff --check` and `git status --short` to validate the working tree; both completed without errors.
- Committed the change with `git commit -m "Fix row input focus loss while typing"` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c637a7900c8327a8a8ca776b3b958b)